### PR TITLE
Make envs revision

### DIFF
--- a/envs/make_envs.sh
+++ b/envs/make_envs.sh
@@ -57,6 +57,9 @@ set -e
         #pip install tflearn
     fi
 
+    # Download some NLTK data (punkt tokenizer)
+    python -m nltk.downloader punkt
+
     # install theano and keras
     pip install nose-parameterized Theano keras
 

--- a/envs/make_envs.sh
+++ b/envs/make_envs.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 # Create conda environments and Jupyter kernels for Pythia
-# Adds Pythia repo root to PYTHONPATH so its source tree can be imported 
+# Adds Pythia repo root to PYTHONPATH so its source tree can be imported
 # in Python
 # Requires Anaconda and Jupyter
 
+set -e
+
 PYTHIA_CONFIG="$1"
 if [ "$PYTHIA_CONFIG" = "" ]; then
-    printf "Must pass in JSON object of configuration variables.\nSuggested usage:"
-    printf "make_envs.sh <(echo \"{\\\\\"PYTHONPATH\\\\\":\\\\\"\$PYTHONPATH\\\\\"}\")\n"
-    exit 1
+    printf "Did not pass in JSON file of configuration variables.\n"
+    printf "Continuing with PYTHONPATH pass-through...\n"
+    printf "Alternative usage: \n"
+    printf "\tmake_envs.sh config.json\n\n"
+    PYTHIA_CONFIG='{ "PYTHONPATH" : "'"$PYTHONPATH"'" }'
 else
     PYTHIA_CONFIG="$(cat $PYTHIA_CONFIG)"
 fi

--- a/envs/make_envs.sh
+++ b/envs/make_envs.sh
@@ -52,13 +52,13 @@ set -e
 
     # install tensorflow (CPU) and tflearn (py3.4 only)
     if [ "$python_version" = "3.4" ]; then
-        pip install --upgrade \
+        pip install \
         https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.8.0-cp34-cp34m-linux_x86_64.whl && \
-        pip install --upgrade tflearn
+        #pip install tflearn
     fi
 
     # install theano and keras
-    pip install --upgrade nose-parameterized Theano keras
+    pip install nose-parameterized Theano keras
 
     # install bleeding-edge pylzma (for Stack Exchange)
     pip install git+https://github.com/fancycode/pylzma

--- a/envs/make_envs.sh
+++ b/envs/make_envs.sh
@@ -22,16 +22,19 @@ make_env () {
     env_name="$1"
     display_name="$2"
     python_version="$3"
-    
+
     echo $env_name
     echo $display_name
     echo $python_version
     echo $PYTHIA_CONFIG
 
 
+set +e
+    # Does not work with BSD grep (OS X)
     search_for_environment="$(conda info -e 2>/dev/null | grep -Po '^ *'$env_name'(?= )' | head -n1)"
     echo "Matched environment line: $search_for_environment"
-    source deactivate 2>/dev/null
+    source deactivate 2>/dev/null || true
+set -e
     sleep 2
     if [ "$search_for_environment" = "$env_name" ]; then
         echo "Environment exists, installing original configuration..."
@@ -46,7 +49,7 @@ make_env () {
         # Activate environment
         source activate "$env_name"
     fi
-    
+
     # install tensorflow (CPU) and tflearn (py3.4 only)
     if [ "$python_version" = "3.4" ]; then
         pip install --upgrade \
@@ -68,7 +71,7 @@ make_env () {
 
     # Install the kernel and retrieve its destination directory
     path_info=$(python -m ipykernel install --user --name $env_name --display-name "$display_name")
-    
+
     # Now add environment information on the second line of the new env's kernel.json
     kernel_dir=$(python -c "import re; print(re.sub(r'^.*?(/[^ ]+"$env_name").*$', r'\\1', '$path_info'))")
     kernel_path="$kernel_dir/kernel.json"
@@ -79,7 +82,7 @@ make_env () {
         <(echo ", ") \
         <(sed '1d' "$kernel_path" ) > /tmp/kernel.json
     mv /tmp/kernel.json "$kernel_path"
-    
+
     cat "$kernel_path" && echo ""
 
 }


### PR DESCRIPTION
make-envs.sh now does "the right thing" (passes through PYTHONPATH) when run without arguments.