### PR TITLE
Setting Pythia as default environment for new bash shell in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,14 +58,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
 	build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-#ADD envs/make_envs.sh /usr/bin/make_envs.sh
-
-ADD . /pythiaWork
-WORKDIR /pythiaWork
-ENV PYTHONPATH=/pythiaWork
-
+# Download Pythia project and create environments
+RUN git clone https://github.com/Lab41/pythia.git
+ENV PYTHONPATH=/pythia:$PYTHONPATH
+WORKDIR pythia
 RUN envs/make_envs.sh
 
+# Activate the new conda environment whenever a bash shell is created
+RUN echo "source activate py3-pythia" >> /root/.bashrc
 
 # run tests
 RUN /bin/bash -c 'export THEANO_FLAGS=device=cpu ; source activate py3-pythia; pip install pytest-cov; py.test -v --cov=src --cov-report term-missing'

--- a/src/pipelines/observations.py
+++ b/src/pipelines/observations.py
@@ -185,7 +185,9 @@ def gen_observations(all_clusters, lookup_order, documentData, filename, feature
                 sentences += get_first_and_last_sentence(doc)
 
             if features.lda:
-                ldavector = run_lda(lda, doc, vocab)
+                doclda = run_lda(lda, doc, vocab)
+                corpuslda = run_lda(lda,corpus,vocab)
+                ldavector = np.concatenate([doclda, corpuslda], axis=0)
 
             # Save results in namedtuple and add to array
             postScore = postTuple(corpusName, cluster, documentData[index]["post_id"], documentData[index]["novelty"], similarityScore, tfidfScore, bog, skipthoughts,ldavector)


### PR DESCRIPTION
Set Pythia as default environment for new bash shell in Dockerfile to address open issue #58. Added git clone command to download current version of Pythia code to Docker container.

Modified LDA vector in observations.py to concatenate the document and corpus vectors as the final feature vector.


