### PR TITLE
Make installation output less verbose and increase build timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ MAINTAINER Pythia
 # From: https://github.com/ContinuumIO/docker-images/tree/master/anaconda
 #
 # Except where noted below, docker-anaconda is released under the following terms:
-# 
+#
 # (c) 2012 Continuum Analytics, Inc. / http://continuum.io
 # All Rights Reserved
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
 #     * Redistributions of source code must retain the above copyright
@@ -19,7 +19,7 @@ MAINTAINER Pythia
 #     * Neither the name of Continuum Analytics, Inc. nor the
 #       names of its contributors may be used to endorse or promote products
 #       derived from this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 # ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
 # WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -31,7 +31,7 @@ MAINTAINER Pythia
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificates \
+RUN apt-get update -q --fix-missing && apt-get install -q -y wget bzip2 ca-certificates \
     libglib2.0-0 libxext6 libsm6 libxrender1 \
     git mercurial subversion
 
@@ -40,7 +40,7 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
     /bin/bash /Anaconda2-4.0.0-Linux-x86_64.sh -b -p /opt/conda && \
     rm /Anaconda2-4.0.0-Linux-x86_64.sh
 
-RUN apt-get install -y curl grep sed dpkg && \
+RUN apt-get install -q -y curl grep sed dpkg && \
     TINI_VERSION=0.9.0 && \
     curl -L "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" > tini.deb && \
     dpkg -i tini.deb && \
@@ -54,14 +54,14 @@ ENV PATH /opt/conda/bin:$PATH
 ENV LANG C.UTF-8
 
 # Set up build tools
-RUN apt-get update && apt-get install -y --no-install-recommends --force-yes \
+RUN apt-get update -q && apt-get install -q -y --no-install-recommends --force-yes \
 	build-essential && \
     rm -rf /var/lib/apt/lists/*
 
-# Download Pythia project and create environments
-RUN git clone https://github.com/Lab41/pythia.git
+# Add Pythia repo to image and create environments
+ADD . /pythia
 ENV PYTHONPATH=/pythia:$PYTHONPATH
-WORKDIR pythia
+WORKDIR /pythia
 RUN envs/make_envs.sh
 
 # Activate the new conda environment whenever a bash shell is created
@@ -69,5 +69,5 @@ RUN echo "source activate py3-pythia" >> /root/.bashrc
 
 # run tests
 RUN /bin/bash -c 'export THEANO_FLAGS=device=cpu; export PYTHIA_MONGO_DB_URI=localhost:27017; source activate py3-pythia; pip install pytest-cov; py.test -v --cov=src --cov-report term-missing'
-    
+
 ENTRYPOINT [ "tini", "--" ]

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   services:
     - docker
-    - mongodb
+    - mongo
 test:
   override:
     - docker build -t pythia .:

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,7 @@ machine:
     - mongodb
 test:
   override:
-    - docker build -t pythia .
+    - docker build -t pythia .:
+        timeout: 1200
   post:
     - bash <(curl -s https://codecov.io/bash)

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
 machine:
   services:
     - docker
-    - mongo
 test:
   override:
     - docker build -t pythia .:

--- a/envs/make_envs.sh
+++ b/envs/make_envs.sh
@@ -40,17 +40,17 @@ set -e
     if [ ! "$search_for_environment" = "$env_name" ]; then
         echo "Creating new environment..."
         sleep 2
-        conda create -y --name "$env_name" python="$python_version"
+        conda create -q -y --name "$env_name" python="$python_version"
     fi
 
     # basics
     source activate "$env_name"
-    conda install -y python="$python_version" scikit-learn \
+    conda install -q -y python="$python_version" scikit-learn \
         beautifulsoup4==4.4.1 lxml==3.6.1 jupyter==1.0.0 pandas==0.18.1 nltk==3.2.1 \
         seaborn==0.7.1 gensim==0.12.4 pip==8.1.1 pymongo==3.0.3
 
     # install tensorflow
-    conda install -y -c conda-forge tensorflow==0.9.0
+    conda install -q -y -c conda-forge tensorflow==0.9.0
 
     # Download some NLTK data (punkt tokenizer)
     python -m nltk.downloader punkt
@@ -59,14 +59,14 @@ set -e
     pip install xgboost
 
     # install theano and keras
-    pip install nose-parameterized==0.5.0 Theano==0.8.2 keras==1.0.7
+    pip install -q nose-parameterized==0.5.0 Theano==0.8.2 keras==1.0.7
 
     # install bleeding-edge pylzma (for Stack Exchange)
-    pip install git+https://github.com/fancycode/pylzma@996570e
+    pip install -q git+https://github.com/fancycode/pylzma@996570e
 
     # Install Sacred (with patch for parse error)
     # pip install sacred
-    pip install docopt==0.6.2 pymongo==3.0.3
+    pip install -q docopt==0.6.2 pymongo==3.0.3
     save_dir=`pwd`
     rm -rf /tmp/sacred || true
     git clone https://github.com/IDSIA/sacred /tmp/sacred
@@ -77,7 +77,7 @@ set -e
     cd "$save_dir"
 
     # install Jupyter kernel, preserving PYTHONPATH and adding Pythia
-    pip install ipykernel==4.3.1
+    pip install -q ipykernel==4.3.1
 
     # Install the kernel and retrieve its destination directory
     path_info=$(python -m ipykernel install --user --name $env_name --display-name "$display_name")


### PR DESCRIPTION
The progress bar printouts are filling up the CircleCI logs and making them much less usable; we can increase the timeout to avoid failed builds.