### PR TITLE
Document a Dockerized example run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN apt-get update -q && apt-get install -q -y --no-install-recommends --force-y
 	build-essential && \
     rm -rf /var/lib/apt/lists/*
 
+ENTRYPOINT [ "tini", "--" ]
+
 # Add Pythia repo to image and create environments
 ADD . /pythia
 ENV PYTHONPATH=/pythia:$PYTHONPATH
@@ -70,4 +72,3 @@ RUN echo "source activate py3-pythia" >> /root/.bashrc
 # run tests
 RUN /bin/bash -c 'export THEANO_FLAGS=device=cpu; export PYTHIA_MONGO_DB_URI=localhost:27017; source activate py3-pythia; pip install pytest-cov; py.test -v --cov=src --cov-report term-missing'
 
-ENTRYPOINT [ "tini", "--" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:14.04
 MAINTAINER Pythia
 
 # Install Anaconda

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,11 @@ ENV PYTHONPATH=/pythia:$PYTHONPATH
 WORKDIR /pythia
 RUN envs/make_envs.sh
 
+# Install MongoDB service and set default value for PYTHIA_MONGO_DB_URI
+RUN apt-get update -q && apt-get install -qy mongodb-server
+ENV PYTHIA_MONGO_DB_URI=localhost:27017
+#RUN echo "service mongodb start" | tee -a /root/.bashrc
+
 # Activate the new conda environment whenever a bash shell is created
 RUN echo "source activate py3-pythia" >> /root/.bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,8 @@ RUN envs/make_envs.sh
 # Install MongoDB service and set default value for PYTHIA_MONGO_DB_URI
 RUN apt-get update -q && apt-get install -qy mongodb-server
 ENV PYTHIA_MONGO_DB_URI=localhost:27017
-#RUN echo "service mongodb start" | tee -a /root/.bashrc
+RUN echo "mongod --dbpath /opt/db --logpath /opt/dblog &" | tee -a /root/.bashrc && \
+    mkdir -p /opt/db
 
 # Activate the new conda environment whenever a bash shell is created
 RUN echo "source activate py3-pythia" >> /root/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,14 +66,10 @@ ENV PYTHONPATH=/pythia:$PYTHONPATH
 WORKDIR /pythia
 RUN envs/make_envs.sh
 
-# Install MongoDB service and set default value for PYTHIA_MONGO_DB_URI
-RUN apt-get update -q && apt-get install -qy mongodb-server
-ENV PYTHIA_MONGO_DB_URI=localhost:27017
-RUN echo "mongod --dbpath /opt/db --logpath /opt/dblog &" | tee -a /root/.bashrc && \
-    mkdir -p /opt/db
-
-# Activate the new conda environment whenever a bash shell is created
-RUN echo "source activate py3-pythia" >> /root/.bashrc
+# Set py3-pythia as default in container
+ENV PATH /opt/conda/envs/py3-pythia/bin:$PATH
+ENV CONDA_DEFAULT_ENV py3-pythia
+ENV CONDA_ENV_PATH /opt/conda/envs/py3-pythia
 
 # run tests
 RUN /bin/bash -c 'export THEANO_FLAGS=device=cpu; export PYTHIA_MONGO_DB_URI=localhost:27017; source activate py3-pythia; pip install pytest-cov; py.test -v --cov=src --cov-report term-missing'

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,3 +74,4 @@ ENV CONDA_ENV_PATH /opt/conda/envs/py3-pythia
 # run tests
 RUN /bin/bash -c 'export THEANO_FLAGS=device=cpu; export PYTHIA_MONGO_DB_URI=localhost:27017; source activate py3-pythia; pip install pytest-cov; py.test -v --cov=src --cov-report term-missing'
 
+CMD [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ We welcome your contributions (see our [contributor guidelines](CONTRIBUTING.md)
 docker build -t lab41/pythia .     # runs tests and builds project image
 ```
 
+## Run a quick experiment
+
+```sh
+docker run -it lab41/pythia experiments/experiments.py with 'XGB=True' 'BOW_APPEND=True' 'BOW_PRODUCT=True'
+```
+
 ## Prerequisites
 
 Our code is written in Python 3. [envs/make_envs.sh](envs/make_envs.sh) will install the necessary dependencies on a Debian/Ubuntu system with Anaconda installed.

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -16,15 +16,15 @@ def set_up_xp():
     # Check that MongoDB config is set
     try:
         mongo_uri=os.environ['PYTHIA_MONGO_DB_URI']
-    except KeyError as e:
-        print("Must define location of MongoDB in PYTHIA_MONGO_DB_URI for observer output",file=sys.stderr)
-        raise
-
-    ex = Experiment(ex_name)
-    ex.observers.append(MongoObserver.create(url=mongo_uri,
+        ex = Experiment(ex_name)
+        ex.observers.append(MongoObserver.create(url=mongo_uri,
                                          db_name=db_name))
-    return ex
+    except KeyError as e:
+        print("You must define location of MongoDB in PYTHIA_MONGO_DB_URI to record experiment output",file=sys.stderr)
+        print("Proceeding without an observer! Results will not be logged!",file=sys.stderr)
+        ex = Experiment(ex_name)
 
+    return ex
 
 xp = set_up_xp()
 


### PR DESCRIPTION
Sets some reasonable defaults in the pythia Docker image so that experiments.py will run, and enables running experiments without the Sacred MongoDB location specified. I tinkered with installing a toy MongoDB local to the image but that did not work.