### PR TITLE
Make Sacred log full results, data directory, classifier parameters when using hyperopt

### DIFF
--- a/experiments/hyperopt_experiments.py
+++ b/experiments/hyperopt_experiments.py
@@ -30,9 +30,9 @@ def objective(args_):
     try:
         ex = Experiment('Hyperopt')
         ex.observers.append(MongoObserver.create(url=parse_args.mongo_db_address, db_name=parse_args.mongo_db_name))
-        ex.main(lambda: run_with_global_args())
+        ex.main(run_with_global_args)
         r = ex.run(config_updates=args)
-        print(r)
+        logger.debug("Experiment result: {}\nReport to hyperopt: {}".format(r, result))
 
         return result
 
@@ -43,14 +43,14 @@ def objective(args_):
         run_with_global_args()
 
 args = None
-result = 100
+result = 100.
 def run_with_global_args():
     global args
     global result
     try:
         all_results = master_pipeline.main(args_to_dicts(args))
         result = -np.mean(all_results['f score'])
-        return result
+        return all_results
     except:
         # Currently errors do not occur too frequently, so skip by returning a zero score
         #raise

--- a/experiments/hyperopt_experiments.py
+++ b/experiments/hyperopt_experiments.py
@@ -84,21 +84,21 @@ def run_pythia_hyperopt():
     space = {
         "algorithm_type":hp.choice('algorithm_type', [
                 {
-                    'type': 'log_reg',
-                    'log_C': hp.choice('log_C', [1e-5, 1e-4, 1e-3, 1e-2, 1, 10]),
-                    'log_tol': hp.choice('log_tol', [1e-5, 1e-4, 1e-3, 1e-2, 1, 10]),
-                    'log_penalty': hp.choice('log_penalty', ["l1", "l2"])
+                    'LOG_REG': True,
+                    'LOG_C': hp.choice('log_C', [1e-5, 1e-4, 1e-3, 1e-2, 1, 10]),
+                    'LOG_TOL': hp.choice('log_tol', [1e-5, 1e-4, 1e-3, 1e-2, 1, 10]),
+                    'LOG_PENALTY': hp.choice('log_penalty', ["l1", "l2"])
                 }, {
-                    'type':'svm',
-                    'svm_C': hp.choice('svm_C', [2000, 1000]),
-                    'svm_kernel': hp.choice('svm_kernel', ['linear', 'poly', 'rbf', 'sigmoid']),
-                    'svm_gamma': hp.choice('svm_gamma', ['auto', 1000, 5000, 10000])
+                    'SVM': True,
+                    'SVM_C': hp.choice('svm_C', [2000, 1000]),
+                    'SVM_KERNEL': hp.choice('svm_kernel', ['linear', 'poly', 'rbf', 'sigmoid']),
+                    'SVM_GAMMA': hp.choice('svm_gamma', ['auto', 1000, 5000, 10000])
                 }, {
-                    'type': 'xgb',
-                    'x_learning_rate': hp.choice('x_learning_rate', [0.01, 0.1, 0.5, 1]),
-                    'x_max_depth': hp.choice('x_max_depth',[3,4,5,6]),
-                    'x_colsample_bytree': hp.choice('x_colsample_bytree', [0.25, 0.5, 0.75, 1]),
-                    'x_colsample_bylevel': hp.choice('x_colsample_bylevel', [0.25, 0.5, 0.75, 1])
+                    'XGB': True,
+                    'XGB_LEARNRATE': hp.choice('x_learning_rate', [0.01, 0.1, 0.5, 1]),
+                    'XGB_MAXDEPTH': hp.choice('x_max_depth',[3,4,5,6]),
+                    'XGB_COLSAMPLEBYTREE': hp.choice('x_colsample_bytree', [0.25, 0.5, 0.75, 1]),
+                    'XGB_MINCHILDWEIGHT': hp.choice('x_colsample_bylevel', [0.25, 0.5, 0.75, 1])
                 } ]),
 
         "BOW_APPEND":hp.choice('BOW_APPEND', [True, False]),

--- a/experiments/hyperopt_experiments.py
+++ b/experiments/hyperopt_experiments.py
@@ -123,8 +123,8 @@ def run_pythia_hyperopt():
         "W2V_MAX":hp.choice('W2V_MAX', [True, False]),
         "W2V_MIN":hp.choice('W2V_MIN', [True, False]),
         "W2V_ABS":hp.choice('W2V_ABS', [True, False]),
-        # This can also be set...but in order for it to go faster W2V_PRETRAINED is set to True above
-    #     "W2V_PRETRAINED",
+        # Training parameters can also be set...but in order for it to go faster W2V_PRETRAINED is set to True
+        'W2V_PRETRAINED': True,
     #     "W2V_MIN_COUNT",
     #     "W2V_WINDOW",
     #     "W2V_SIZE",
@@ -137,20 +137,20 @@ def run_pythia_hyperopt():
         # Also mem nets aren't in here as they run on their own
     #     "WORDONEHOT",
     #     "WORDONEHOT_VOCAB",
-    #     "RESAMPLING",
     #     "NOVEL_RATIO",
-    #     "OVERSAMPLING",
     #     "REPLACEMENT",
     #     "SAVEEXPERIMENTDATA",
     #     "EXPERIMENTDATAFILE",
+        'directory': parse_args.directory_base,
+        'RESAMPLING': True,
+        "OVERSAMPLING": True,
+        'USE_CACHE': True,
         "VOCAB_SIZE": hp.choice('VOCAB_SIZE', [1000, 5000, 10000, 20000]),
         "STEM": hp.choice('STEM', [True, False]),
         "FULL_VOCAB_SIZE": hp.choice('FULL_VOCAB_SIZE', [1000, 5000, 10000, 20000]),
         "FULL_VOCAB_TYPE": hp.choice('FULL_VOCAB_TYPE', ['word', 'character']),
     #     "FULL_CHAR_VOCAB",
-    #     "SEED",
-    #     'USE_CACHE'
-        'SAVE_RESULTS': hp.choice('SAVE_RESULTS', [True])
+        'SAVE_RESULTS': True
     }
     trials = Trials()
     best = fmin(objective, space, algo=tpe.suggest, max_evals=int(parse_args.num_runs), trials=trials)

--- a/experiments/hyperopt_experiments.py
+++ b/experiments/hyperopt_experiments.py
@@ -6,17 +6,19 @@ import os
 os.environ["THEANO_FLAGS"] = "mode=FAST_RUN,device=gpu,floatX=float32,allow_gc=True,lib.cnmem=0"  # Sets flags for use of GPU
 from src.pipelines import parse_json, preprocess, data_gen, log_reg, svm, xgb, predict, master_pipeline
 import pickle
-import src.pipelines.master_pipeline as mp
-import numpy as np
+import logging
 import copy
-from src.pipelines.master_pipeline import main as pythia_main
+
+import numpy as np
 from sklearn.metrics import precision_recall_fscore_support
 from sacred import Experiment
 from sacred.observers import MongoObserver
 from sacred.initialize import Scaffold
-
 import hyperopt
 from hyperopt import fmin, tpe, hp, STATUS_OK, Trials
+
+import src.pipelines.master_pipeline as mp
+from src.pipelines.master_pipeline import main as pythia_main
 
 def objective(args_):
 


### PR DESCRIPTION
When using hyperopt, Sacred does not receive:
1. the full results dict as logged in `experiments.py`
2. the data directory, which we use to identify the data source
and it logged classifier parameters in an idiosyncratic way. This PR addresses all three issues, so that Sacred logs the same results for Hyperopt-controlled and other experiments (and Hyperopt still sees only `-F1`), the data directory is stored alongside other run hyperparameters, and classifier hyperparameters are logged as in other experiments. This will make it possible to compare results from Hyperopt-controlled experiments to other experiments.