### PR TITLE
Modify Word2Vec Analysis of Background Documents

### DIFF
--- a/src/pipelines/data_gen.py
+++ b/src/pipelines/data_gen.py
@@ -210,10 +210,14 @@ def w2v(doc, background_docs, w2v_model, w2v, feature):
         background_vectors = list()
         for entry in background_docs:
             background_vectors.append(run_w2v_elemwise(w2v_model, entry, w2v, operation))
-        backgroundw2v = np.mean(background_vectors, axis=0)
+        if operation == 'min':
+            backgroundw2v = np.amin(background_vectors, axis=0)
+        elif operation == 'max':
+            backgroundw2v = np.amax(background_vectors, axis=0)
+        elif operation == 'abs':
+            backgroundw2v = np.fabs(background_vectors)[0]
         vectors = [docw2v,backgroundw2v]
         feature = gen_feature(vectors, w2v, feature)
-
     return feature
 
 def run_w2v_elemwise(w2v_model, doc, w2v, operation):

--- a/src/pipelines/data_gen.py
+++ b/src/pipelines/data_gen.py
@@ -215,7 +215,7 @@ def w2v(doc, background_docs, w2v_model, w2v, feature):
         elif operation == 'max':
             backgroundw2v = np.amax(background_vectors, axis=0)
         elif operation == 'abs':
-            backgroundw2v = np.fabs(background_vectors)[0]
+            backgroundw2v = np.amax(np.fabs(background_vectors), axis=0)
         vectors = [docw2v,backgroundw2v]
         feature = gen_feature(vectors, w2v, feature)
     return feature


### PR DESCRIPTION
Update to data_gen.py to have Word2Vec examine each document in the list of background documents. 

The returned word vector for each background document is combined into a list and then averaged to provide a single word vector representation of the background documents.
